### PR TITLE
fix: buildLegend wasn't able to handle simple symbol type

### DIFF
--- a/src/reportParts/HazardUnit.tsx
+++ b/src/reportParts/HazardUnit.tsx
@@ -21,8 +21,6 @@ const HazardUnit: FC<HazardUnitProps> = ({ HazardUnit, Description }) => {
 
   useEffect(() => {
     const buildLegend = async (renderer: any) => {
-      // console.log('buildLegend', renderer);
-
       setHasLegend(true);
 
       // const { symbolUtils } = await getModules();
@@ -30,6 +28,10 @@ const HazardUnit: FC<HazardUnitProps> = ({ HazardUnit, Description }) => {
 
       if (renderer.type === 'unique-value') {
         renderers = renderer.uniqueValueInfos.filter((info: any) => info.value === HazardUnit);
+      }
+
+      if (renderers.type = 'simple') {
+        renderers = [renderer];
       }
 
       if (renderers.length !== 1) {


### PR DESCRIPTION
![image](https://github.com/UGS-GIO/hazards-report-tool/assets/24685932/5c4b1b95-29d9-46bc-941d-c85007028917)


the legend symbology now shows